### PR TITLE
Backup Gemfile.lock to prevent Bundler changing it. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,13 @@ commands:
   install_dependencies:
     steps:
       - run: gem install bundler -v '2.2.14'
+      - run: cp Gemfile.lock Gemfile.lock.bak
       - restore_cache:
           keys:
-            - rails_template-{{ checksum "Gemfile.lock" }}
+            - rails_template-{{ checksum "Gemfile.lock.bak" }}
       - run: bundle install --path ./vendor/bundle
       - save_cache:
-          key: rails_template-{{ checksum "Gemfile.lock" }}
+          key: rails_template-{{ checksum "Gemfile.lock.bak" }}
           paths:
             - ./vendor/bundle
       - restore_cache:


### PR DESCRIPTION
Bundler appends the version of bundler used to bundle install, so it was
changing the Gemfile.lock out from under us.

Closes #20 

![Screen Shot 2022-01-20 at 3 11 33 PM](https://user-images.githubusercontent.com/2806645/150436780-844feba9-df7b-4fd0-a9e0-59f1f21d679e.png)

