### PR TITLE
Update Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
           RAILS_ENV: test
     steps:
       - browser-tools/install-browser-tools
+      - run:
+          name: remove errant LICENSE file
+          command: rm LICENSE.chromedriver
       - checkout
       - node/install:
           install-yarn: true


### PR DESCRIPTION
Addresses the error "Directory (/home/circleci/rails_template) you are trying to checkout to is not empty and not a git repository" that was causing CI to fail in the build stage. 